### PR TITLE
Fix Landing Screen Firebase

### DIFF
--- a/MobileApp/src/screens/LandingScreen/LandingScreen.js
+++ b/MobileApp/src/screens/LandingScreen/LandingScreen.js
@@ -4,13 +4,17 @@ import auth from '@react-native-firebase/auth';
 import {LOGO} from '../../images/index';
 
 class LandingScreen extends React.Component {
-  componentDidMount() {
-    auth().onAuthStateChanged(user => {
+  async componentWillMount() {
+    
+    await auth().onAuthStateChanged(user => {
       if (user) {
         this.props.navigation.navigate('App');
       } else {
         this.props.navigation.navigate('SignIn');
       }
+    }).catch(() => {
+      this.setState({ error: 'Authentication Failed.' });
+      this.props.navigation.navigate('SignIn');
     });
   }
 


### PR DESCRIPTION
## Description
On iOS, the application failed to run upon trying to render the component with Firebase handlers without first initializing Firebase Auth and creating the application.
With this, the initialization was moved to `componentWillMount` so that it would be executed prior to rendering, so that we can properly redirect the user via navigation, perform initialization, and such. We also await these functions to prevent errors experienced with faster devices.
(Seems that it just defers it to not being able to load the screen, but the app successfully launches).
## Related Issue
#47 
<img width="471" alt="Screen Shot 2020-01-04 at 10 03 22 AM" src="https://user-images.githubusercontent.com/29003194/71772530-6cd86e80-2f1a-11ea-95dc-faa0d2a3f12d.png">

